### PR TITLE
chore: add publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,13 @@
+# .github/workflows/publish.yml
+name: Publish to pub.dev
+
+on:
+  release:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  publish:
+    permissions:
+      id-token: write
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

This pull request introduces a new GitHub Actions workflow to automate publishing to `pub.dev` upon creating a release. 

Automation for publishing:

* [`.github/workflows/publish.yaml`](diffhunk://#diff-e81e13daadd1745de51d8b8d85fce1fcd9be355732b64d60a6b56e18c28388caR1-R13): Added a new workflow named "Publish to pub.dev" that triggers on release tags matching semantic versioning (`v[0-9]+.[0-9]+.[0-9]+`) and uses the `dart-lang/setup-dart` action to handle the publishing process.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
